### PR TITLE
Update layout height from calc(100vh-4rem) to 100vh

### DIFF
--- a/client/components/layout/ConsoleLayout.tsx
+++ b/client/components/layout/ConsoleLayout.tsx
@@ -17,7 +17,7 @@ const ConsoleLayout: React.FC<ConsoleLayoutProps> = ({ children }) => {
   return (
     <div className="h-screen overflow-hidden bg-gray-50 pt-16">
       <ConsoleNavbar fixed />
-      <main className="w-full px-4 sm:px-6 lg:px-8 py-8 h-[calc(100vh-4rem)] overflow-y-auto">
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-8 h-[100vh] overflow-y-auto">
         {children}
       </main>
     </div>

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -63,7 +63,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
       )}
 
       {/* Body area below navbar */}
-      <div className="pt-16 flex h-[calc(100vh-4rem)] w-full overflow-hidden">
+      <div className="pt-16 flex h-[100vh] w-full overflow-hidden">
         {/* Sidebar */}
         <div
           className={cn(


### PR DESCRIPTION
## Purpose
The user requested to find the `h-[calc(100vh-4rem)]` style and adjust the height calculation to use `100vh` instead. This change simplifies the height calculation by removing the 4rem offset.

## Code changes
- **ConsoleLayout.tsx**: Changed main element height from `h-[calc(100vh-4rem)]` to `h-[100vh]`
- **DashboardLayout.tsx**: Changed body area height from `h-[calc(100vh-4rem)]` to `h-[100vh]`

Both layout components now use full viewport height without subtracting the 4rem offset.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a2443db76dc2427da7dcb3e18c76118f/curry-oasis)

👀 [Preview Link](https://a2443db76dc2427da7dcb3e18c76118f-curry-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a2443db76dc2427da7dcb3e18c76118f</projectId>-->
<!--<branchName>curry-oasis</branchName>-->